### PR TITLE
Add incoming email rules module

### DIFF
--- a/incoming_email_rules/__init__.py
+++ b/incoming_email_rules/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/incoming_email_rules/__manifest__.py
+++ b/incoming_email_rules/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name': 'Incoming Email Rules',
+    'version': '1.0',
+    'summary': 'Define rules for incoming emails to create records',
+    'category': 'Tools',
+    'author': 'Generated',
+    'depends': ['base', 'mail'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/incoming_email_rule_views.xml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/incoming_email_rules/models/__init__.py
+++ b/incoming_email_rules/models/__init__.py
@@ -1,0 +1,1 @@
+from . import incoming_email_rule

--- a/incoming_email_rules/models/incoming_email_rule.py
+++ b/incoming_email_rules/models/incoming_email_rule.py
@@ -1,0 +1,32 @@
+from odoo import api, fields, models
+
+
+class IncomingEmailRule(models.Model):
+    _name = 'incoming.email.rule'
+    _description = 'Incoming Email Rule'
+
+    name = fields.Char(required=True)
+    active = fields.Boolean(default=True)
+    from_email = fields.Char(string='From Email')
+    subject_contains = fields.Char(string='Subject Contains')
+    model_id = fields.Many2one('ir.model', string='Target Model', required=True)
+    priority = fields.Integer(default=5)
+    create_user_id = fields.Many2one('res.users', string='Create as User')
+
+    def apply_rule(self, message):
+        """Check if the message matches this rule."""
+        if self.from_email and self.from_email not in message.get('from', ''):
+            return False
+        if self.subject_contains and self.subject_contains not in message.get('subject', ''):
+            return False
+        return True
+
+    def create_record_from_message(self, message):
+        model = self.model_id.model
+        vals = {
+            'name': message.get('subject'),
+            'email_from': message.get('from'),
+            'body': message.get('body', ''),
+        }
+        self.env[model].with_user(self.create_user_id or self.env.user).create(vals)
+        return True

--- a/incoming_email_rules/security/ir.model.access.csv
+++ b/incoming_email_rules/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_incoming_email_rule,access_incoming_email_rule,model_incoming_email_rule,base.group_system,1,1,1,1

--- a/incoming_email_rules/views/incoming_email_rule_views.xml
+++ b/incoming_email_rules/views/incoming_email_rule_views.xml
@@ -1,0 +1,49 @@
+<odoo>
+    <record id="view_incoming_email_rule_form" model="ir.ui.view">
+        <field name="name">incoming.email.rule.form</field>
+        <field name="model">incoming.email.rule</field>
+        <field name="arch" type="xml">
+            <form string="Incoming Email Rule">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="active"/>
+                        <field name="from_email"/>
+                        <field name="subject_contains"/>
+                        <field name="model_id"/>
+                        <field name="create_user_id"/>
+                        <field name="priority"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_incoming_email_rule_tree" model="ir.ui.view">
+        <field name="name">incoming.email.rule.tree</field>
+        <field name="model">incoming.email.rule</field>
+        <field name="arch" type="xml">
+            <tree string="Incoming Email Rules" default_order="priority">
+                <field name="name"/>
+                <field name="active"/>
+                <field name="from_email"/>
+                <field name="subject_contains"/>
+                <field name="model_id"/>
+                <field name="create_user_id"/>
+                <field name="priority"/>
+            </tree>
+        </field>
+    </record>
+
+    <menuitem id="menu_incoming_email_rule_root" name="Incoming Email Rules" parent="mail.mail_follower_menu"/>
+    <menuitem id="menu_incoming_email_rule" name="Rules" parent="menu_incoming_email_rule_root" action="action_incoming_email_rule"/>
+
+    <record id="action_incoming_email_rule" model="ir.actions.act_window">
+        <field name="name">Incoming Email Rules</field>
+        <field name="res_model">incoming.email.rule</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p>Create rules to automate creation of records from incoming emails.</p>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- add a new Odoo module called incoming_email_rules
- add model `incoming.email.rule` with fields to match emails and create target records
- add basic security and views to manage these rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683bbdf33ed4832080e2dedd0badf812